### PR TITLE
fix: typing on prices of ProductVariant

### DIFF
--- a/src/types/product-variant/index.ts
+++ b/src/types/product-variant/index.ts
@@ -6,7 +6,7 @@ export interface ProductVariant {
   title: string;
   product_id: string;
   product: Product;
-  prices: MoneyAmount;
+  prices: MoneyAmount[];
   sku?: string;
   barcase?: string;
   ean?: string;


### PR DESCRIPTION
**What**
-Fixes type of prices on ProductVariant

**Why**

Currently there is a mismatch between type and actual type. See model from core:

https://github.com/medusajs/medusa/blob/b0420b32495a67f317db149f28723c7d3b1f7a1a/packages/medusa/src/models/product-variant.ts#L48